### PR TITLE
Build, test and deploy with AppVeyor

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -39,17 +39,42 @@ $checksum       = 'c7c957dd0e8ce34a1cedc752447e217e'
 $url64          = 'https://github.com/docker/machine/releases/download/v0.2.0/docker-machine_windows-amd64.exe'
 $checksum64     = '5e8935f6ab2f6627b4163cb4c68191ef'
 
-#### 3. Package it
+#### 4. Update appveyor.yml
+
+You need to update `version` with the official docker-machine version.
+
+#### 5. Git push
+
+Push your changes to GitHub and check the AppVeyor build. See the AppVeyor build section below for details.
+
+    git push
+
+#### 6. Git tag
+
+After a successfull AppVeyor build tag the sources and push the new tag to GitHub. This step builds and tests the package and pushes the new package to Chocolatey.
+
+    git tag 0.5.0
+    git push --tags
+
+## AppVeyor build
+
+The docker-machine chocolatey package is built with the AppVeyor CI service.
+
+### Build steps
+
+#### Package it
 
 Open a command line window and run the following command in the folder
 where `docker.nuspec` exists:
 
-    `cpack`
+    cpack
 
 It might show some warnings, but if there's no errors, it's completed.
 Check if a `.nupkg` file exists in the same directory after this.
 
-#### 4. Install it locally
+### Test steps
+
+#### Install it locally
 
 First, make sure `docker-machine` is not installed (or not in %PATH%). (Cleanest
 way to do this is to run inside a clean virtual machine but that's not
@@ -66,29 +91,35 @@ you're currently in the :
 The command above must be installing docker-machine correctly. Run `docker-machine -v`
 to verify if it is installed.
 
+#### Run further tests
+
 Run the following commands to verify uninstallation works:
 
     choco uninstall docker-machine
     docker-machine // shouldn't work
 
-#### 5. Upload the package
+See the script `test.ps1` for all tests that run on AppVeyor.
 
-> **CAUTION:** You can upload a version only once (chocolatey does not
-> allow overwriting packages). Therefore be careful since you can do
-> this step only once without changing `<version>` string. Note, you _can_
-> upload multiple times until the package has been approved.
+### Deploy steps
 
+#### Push the package
+
+You need your API key to push Chocolatey packages.
 Go to http://chocolatey.org and log in.
 
-Click **Upload** tab.
+Go to your account settings and show your API key.
 
-Choose the binary.
+Copy the example command with your key
 
-Review the version number and details.
+    choco apiKey -k your-api-key -source https://chocolatey.org/
 
-Hit "Upload" button.
+Push the package
 
-#### 6. Approval Process
+    choco push docker-machine.0.5.0.nupkg
+
+While in moderation you can push the package again to fix errors in the description or installation script etc.
+
+## Approval Process
 
 If you are submitting a stable version, Chocolatey moderators need to
 allow the package before it is published. This usually takes a day or
@@ -112,6 +143,6 @@ and pre-release packages with:
 command and Chocolatey usually prompts users with more confirmation
 messages if the package is pre-release.
 
-#### 7. Profit
+## Profit
 
 Package will be published at https://chocolatey.org/packages/docker-machine

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # chocolatey installer for docker-machine
 
+[![Latest version released](https://img.shields.io/chocolatey/v/docker-machine.svg)](https://chocolatey.org/packages/docker-machine)
+[![Package downloads count](https://img.shields.io/chocolatey/dt/docker-machine.svg)](https://chocolatey.org/packages/docker-machine)
+[![Build status](https://ci.appveyor.com/api/projects/status/kar8vn7rcytkttnb/branch/master?svg=true)](https://ci.appveyor.com/project/StefanScherer/choco-docker-machine/branch/master)
+
 This is a chocolatey package for docker-machine. Please see MAINTENANCE.md
 for information on how to upkeep it.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 0.5.0.{build}
+environment:
+  TOKEN:
+    secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
+
+build_script:
+  - ps: cpack
+
+test_script:
+  - ps: .\test.ps1
+
+deploy_script:
+  - ps: >-
+      Write-Host $env:APPVEYOR_REPO_TAG ;
+      if($env:APPVEYOR_REPO_BRANCH -eq 'master' -And $env:APPVEYOR_REPO_TAG -eq 'true') {
+        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$') ;
+        choco apiKey -k $env:TOKEN -source https://chocolatey.org/ ;
+        choco push docker-machine.$version.nupkg
+      }
+
+artifacts:
+  - path: '**\*.nupkg'
+    name: Package

--- a/docker-machine.nuspec
+++ b/docker-machine.nuspec
@@ -11,9 +11,16 @@
     </description>
     <projectUrl>https://github.com/docker/machine</projectUrl>
     <packageSourceUrl>https://github.com/silarsis/choco-docker-machine</packageSourceUrl>
+    <projectSourceUrl>https://github.com/docker/machine</projectSourceUrl>
+    <docsUrl>https://docs.docker.com/machine/</docsUrl>
+    <bugTrackerUrl>https://github.com/docker/machine/issues</bugTrackerUrl>
     <iconUrl>https://raw.githubusercontent.com/docker/machine/master/docs/img/logo.png</iconUrl>
-    <tags>docker-machine docker</tags>
     <licenseUrl>https://github.com/docker/machine/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>docker-machine docker</tags>
+    <releaseNotes>https://github.com/docker/machine/releases</releaseNotes>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
 </package>

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,45 @@
+"Running tests"
+$ErrorActionPreference = "Stop"
+$version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
+
+"TEST: Version $version in docker-machine.nuspec file should match"
+[xml]$spec = Get-Content docker-machine.nuspec
+if ($spec.package.metadata.version.CompareTo($version)) {
+  Write-Error "FAIL: rong version in nuspec file!"
+}
+
+"TEST: Package should contain only install script"
+Add-Type -assembly "system.io.compression.filesystem"
+$zip = [IO.Compression.ZipFile]::OpenRead("$pwd\docker-machine.$version.nupkg")
+if ($zip.Entries.Count -ne 5) {
+  Write-Error "FAIL: Wrong count in nupkg!"
+}
+$zip.Dispose()
+
+"TEST: Installation of package should work"
+. choco install -y docker-machine -source .
+
+"TEST: Version of binary should match"
+if (-Not $(docker-machine --version).Contains("version $version ")) {
+  Write-Error "FAIL: Wrong version of docker-machine installed!"
+}
+
+"TEST: Create a machine with driver none should work"
+. docker-machine create -d none --url http://127.0.0.1:2376 test
+
+"TEST: List should show the machine"
+. docker-machine ls
+if ($(docker-machine ls).Contains("test   -        none             http://127.0.0.1:2376")) {
+  Write-Error "FAIL: machine not found"
+}
+
+"TEST: Uninstall show remove the binary"
+. choco uninstall docker-machine
+try {
+  . docker-machine
+  Write-Error "FAIL: docker-machine binary still found"
+} catch {
+  Write-Host "PASS: docker-machine not found"
+}
+
+"TEST: Finished"


### PR DESCRIPTION
After pushing the `docker-machine` 0.5.0 package I found some issues. There were too many files in the package. While the package was in approval I've fixed the package, added some more links etc.

But I thought the build, test and deploy cycle should be automated. So I've added an `appveyor.yml` and a `test.ps1` script that runs a test at AppVeyor after each `git push`.

The deployment with `choco push` is only done if we push a git tag to build a new release. I've updated the `MAINTENANCE.md`.

After merging this PR we can try this the next time when 0.5.1 is released.

This saves me from spinning up a fresh Windows VM with Chocolatey and run the tests manually.
