### PR TITLE
Docker machine 0.5.4

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -53,7 +53,7 @@ Push your changes to GitHub and check the AppVeyor build. See the AppVeyor build
 
 After a successfull AppVeyor build tag the sources and push the new tag to GitHub. This step builds and tests the package and pushes the new package to Chocolatey.
 
-    git tag 0.5.2
+    git tag 0.5.4
     git push --tags
 
 ## AppVeyor build
@@ -115,7 +115,7 @@ Copy the example command with your key
 
 Push the package
 
-    choco push docker-machine.0.5.2.nupkg
+    choco push docker-machine.0.5.4.nupkg
 
 While in moderation you can push the package again to fix errors in the description or installation script etc.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.5.2.{build}
+version: 0.5.4.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66

--- a/docker-machine.nuspec
+++ b/docker-machine.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>docker-machine</id>
     <title>docker-machine</title>
-    <version>0.5.2</version>
+    <version>0.5.4</version>
     <authors>Docker Contributors</authors>
     <owners>silarsis</owners>
     <summary>Machine management for a container-centric world</summary>

--- a/test.ps1
+++ b/test.ps1
@@ -65,7 +65,7 @@ try {
 }
 
 "TEST: Update from older version to single binary version works"
-. choco install -y docker-machine $options -version 0.4.1
+. choco install -y docker-machine $options -version 0.5.2
 . choco install -y docker-machine $options -source . -version $version
 . ls C:\programdata\chocolatey\lib\docker-machine
 . ls C:\programdata\chocolatey\lib\docker-machine\tools

--- a/test.ps1
+++ b/test.ps1
@@ -53,7 +53,7 @@ if ($(docker-machine ls).Contains("test   -        none             http://127.0
 }
 
 "TEST: Remove the machine should work"
-. docker-machine rm test
+. docker-machine rm -f test
 
 "TEST: Uninstall show remove the binary"
 . choco uninstall -y docker-machine

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,11 +1,16 @@
 $packageName    = 'docker-machine'
-$url            = 'https://github.com/docker/machine/releases/download/v0.5.2/docker-machine_windows-386.zip'
-$checksum       = '93d5603098d0b4a79ffd91939f8adc02'
-$url64          = 'https://github.com/docker/machine/releases/download/v0.5.2/docker-machine_windows-amd64.zip'
-$checksum64     = '533759e13d66a7d5d536a8a96b5e1227'
+$url            = 'https://github.com/docker/machine/releases/download/v0.5.4/docker-machine_windows-386.exe'
+$checksum       = 'ab53930550dc9cc269106651af1ead63'
+$url64          = 'https://github.com/docker/machine/releases/download/v0.5.4/docker-machine_windows-amd64.exe'
+$checksum64     = '7735afc2f5f431d9b685b74fc9884c59'
 $checksumType   = 'md5'
 $checksumType64 = 'md5'
-$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-Install-ChocolateyZipPackage "docker-machine" "$url" "$unzipLocation" "$url64" `
- -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64
+$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$packageDir  = "$(Split-Path -parent $toolsDir)"
+$installDir  = Join-Path "$packageDir" "bin"
+$installBin  = "${packageName}.exe"
+$installPath = Join-Path "$installDir" "$installBin"
+
+New-Item -ItemType Directory -Force -Path "$installDir"
+Get-ChocolateyWebFile "$packageName" "$installPath" "$url" "$url64" -checksum "$checksum" -checksumType "$checksumType" -checksum64 "$checksum64" -checksumType64 "$checksumType64"

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -12,5 +12,13 @@ $installDir  = Join-Path "$packageDir" "bin"
 $installBin  = "${packageName}.exe"
 $installPath = Join-Path "$installDir" "$installBin"
 
+if ([System.IO.Directory]::Exists("$env:ChocolateyInstall\lib\docker-machine")) {
+  if ([System.IO.Directory]::Exists("$env:ChocolateyInstall\lib\docker-machine\tools")) {
+    # clean old plugins and ignore files
+    Write-Host "Removing old docker-machine plugins"
+    Remove-Item "$env:ChocolateyInstall\lib\docker-machine\tools\docker-machine-*.*"
+  }
+}
+
 New-Item -ItemType Directory -Force -Path "$installDir"
 Get-ChocolateyWebFile "$packageName" "$installPath" "$url" "$url64" -checksum "$checksum" -checksumType "$checksumType" -checksum64 "$checksum64" -checksumType64 "$checksumType64"


### PR DESCRIPTION
Update to docker-machine 0.5.4 which is now a single exe again.
The choco package takes care of removing the plugin exe files in an update.
The tests are updated to test this update scenario.
AppVeyor build and test is green.
